### PR TITLE
Apply same WP_REST formatting to ACF post object values

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -90,4 +90,30 @@ add_action( 'rest_api_init', function() {
             return $response;
         }
     ) );
+
+    add_filter( 'acf/format_value/type=post_object', 'headless_theme_prepare_post_object_for_response' , 10, 3 );
+    function headless_theme_prepare_post_object_for_response( $value, $post_id, $field ) {
+        if ( $field['return_format'] !== 'object' ) {
+            return;
+        }
+
+        if ( is_array( $value ) ) {
+            $formatted = array();
+            foreach( $value as $post ) {
+                $formatted[] = headless_theme_rest_format_post( $post );
+            }
+
+            return $formatted;
+        } else {
+            return headless_theme_rest_format_post( $value );
+        }
+    };
 } );
+
+function headless_theme_rest_format_post( $post ) {
+    $dummy_request = new WP_REST_Request( 'GET', '/' );
+    $dummy_controller = new WP_REST_Posts_Controller( $post->post_type );
+    $response = $dummy_controller->prepare_item_for_response( $post , $dummy_request );
+
+    return $response->data;
+}

--- a/functions.php
+++ b/functions.php
@@ -94,7 +94,7 @@ add_action( 'rest_api_init', function() {
     add_filter( 'acf/format_value/type=post_object', 'headless_theme_prepare_post_object_for_response' , 10, 3 );
     function headless_theme_prepare_post_object_for_response( $value, $post_id, $field ) {
         if ( $field['return_format'] !== 'object' ) {
-            return;
+            return $value;
         }
 
         if ( is_array( $value ) ) {


### PR DESCRIPTION
This uses the WP_REST plugin internals to apply the same JSON schema to post object fields in ACF. This will allow us to reuse most Model logic in our frontend.